### PR TITLE
Open Watcom C Compatibility

### DIFF
--- a/source/kitten.c
+++ b/source/kitten.c
@@ -74,7 +74,7 @@ int dos_open(char *filename, int mode)
 {
 	union REGS r;
         struct SREGS s;
-	if (mode);		/* mode ignored - readonly supported */
+	(void)mode;		/* mode ignored - readonly supported */
 	r.h.ah = 0x3d;
 	r.h.al = 0;		/* read mode only supoported now !! */
 	r.x.dx = FP_OFF(filename);

--- a/source/makefile
+++ b/source/makefile
@@ -10,8 +10,17 @@
 UPX=upx --8086
 
 ############# WATCOM ########################
-# CC=wcl
-# CFLAGS=-oas -s -wx -we -zq -fm -fe=
+# -we treat all warnings as errors
+# -wx set warning level to max
+# -zq operate quietly
+# -fm[=<map_file>]  generate map file
+# -fe=<executable> name executable file
+
+CC=wcl
+CFLAGS=-oas -bt=DOS -zp1 -s -0 -wx -we -zq -fm -fe=
+# -m{t,s,m,c,l,h}  memory model 
+COMFLAGS=-mt -lt
+EXEFLAGS=-mc
 
 ############# TURBO_C ########################
 # -w warn -M create map -f- no floating point -Z register optimize
@@ -22,10 +31,10 @@ UPX=upx --8086
 # *** changed 7/2004: tiny has near qsort / malloc pointers, very limited!
 # compact large: large has far function pointers, compact only far heap.
 # makes no real difference here, but compact saves a few bytes in size.
-CC=tcc
-CFLAGS=-w -M -f- -a- -K -ln -e
-COMFLAGS=-mt -lt -Z -O -k-
-EXEFLAGS=-mc -N -Z -O -k-
+# CC=tcc
+# CFLAGS=-w -M -f- -a- -K -ln -e
+# COMFLAGS=-mt -lt -Z -O -k-
+# EXEFLAGS=-mc -N -Z -O -k-
 
 CFILES=sort.c
 

--- a/source/sort.c
+++ b/source/sort.c
@@ -22,7 +22,13 @@
 #include <string.h>
 
 #include "kitten.h"
+
+#ifdef __WATCOMC__
+#define O_RDONLY        0x0000  /* open for read only */
+#else /* not __WATCOMC__ */
 #include <fcntl.h> /* O_RDONLY */
+#endif
+
 #define StdIN  0
 #define StdOUT 1
 #define StdERR 2
@@ -106,7 +112,7 @@ WriteString(char *s, int handle) /* much smaller than fputs */
 }
 
 int
-cmpr(void *a, void *b)
+cmpr(const void *a, const void *b)
 {
     unsigned char *A, *B, *C;
 


### PR DESCRIPTION
Just a few changes to make this compatible with Open Watcom C ver 2.0 beta.  It also makes Watcom C the default compiler in the makefile. 